### PR TITLE
Extract dhcp client cli

### DIFF
--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -82,7 +82,7 @@
       "mmeGid": 1,
       "mmeRelativeCapacity": 11,
       "mnc": "01",
-      "natEnabled": true,
+      "natEnabled": false,
       "nonEpsServiceControl": 0,
       "relayEnabled": false,
       "tac": 1
@@ -90,7 +90,7 @@
     "mobilityd": {
       "@type": "type.googleapis.com/magma.mconfig.MobilityD",
       "ipBlock": "192.168.128.0/24",
-      "ip_allocator_type": "IP_POOL",
+      "ip_allocator_type": "DHCP",
       "ipv6Block": "fdee:5:6c::/48",
       "ipv6PrefixAllocationType": "RANDOM",
       "logLevel": "INFO",
@@ -109,7 +109,7 @@
       "enable5gFeatures": false,
       "liUes": {},
       "logLevel": "INFO",
-      "natEnabled": true,
+      "natEnabled": false,
       "services": [
         "DPI",
         "ENFORCEMENT"

--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -14,5 +14,6 @@
 # log_level is set in mconfig. it can be overridden here
 redis_port: 6380
 print_grpc_payload: false
+dhcp_iface: eth0
 
 ipv6_prefixlen: 58

--- a/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
@@ -121,7 +121,7 @@ class IPv6AllocatorPool(IPAllocator):
             self._assigned_ip_block,
         )
         self._assigned_ip_block = None
-        self._store.assigned_ip_blocks -= removed_blocks
+        self._store.assigned_ip_blocks -= set(removed_blocks)
 
         return removed_blocks
 


### PR DESCRIPTION
## Summary

To get the basic `test_attach_detach` to run with DHCP, the folowing steps are necessary:
* Set mobilityd to  DHCP mode:
  *  add `dhcp_iface: eth0` to `mobilityd.yml`
  * change `"ip_allocator_type": "DHCP",` in `gateway.mconfig` under mobilityd
* set non-nat mode, i.e. `"natEnabled": false,` for mme and pipelined in `gateway.mconfig`

Run the test and check with wireshark if the DHCP packages are coming threough. (The test does not work currently)

## Test Plan



## Additional Information

- [ ] This change is backwards-breaking


